### PR TITLE
Update minimatch to 3.0.3, add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -38,9 +38,6 @@ globSync = function (pat) {
 
   if (files) {
     pat = path.normalize(pat);
-    // Hack, Minimatch doesn't support backslashes in the pattern
-    // https://github.com/isaacs/minimatch/issues/7
-    pat = pat.replace(/\\/g, '/');
     matches = minimatch.match(files, pat, {});
   }
   return matches || [];

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Lazy-evaluating list of files, based on globs or regex patterns",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jake test"
   },
   "repository": {
     "type": "git",
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/mde/filelist",
   "dependencies": {
-    "minimatch": "0.3.0",
+    "minimatch": "3.0.3",
     "utilities": "0.0.37"
   }
 }

--- a/test/filelist.js
+++ b/test/filelist.js
@@ -17,6 +17,10 @@ tests = {
     jake.rmRf('./test/tmp/one', {silent: true});
   }
 
+, 'after': function () {
+    jake.rmRf('./test/tmp', {silent:true});
+  }
+
 , 'path separator can be used by exclude': function () {
     var fileList = new FileList();
     fileList.include("test/tmp/one/**/*.txt");


### PR DESCRIPTION
- Update `minimatch` to latest [stable version](https://travis-ci.org/isaacs/minimatch/builds/150706959) 
   - `npm` emits a warning about a vulnerability if `minimatch`'s version is specified below `3.0.2`
- Remove substitution of backslashes for Windows compatibility, issue [has been fixed in minimatch](https://github.com/isaacs/minimatch/commit/b6f01f5ecb7636a34d0481732e4799c2a30334f1)  by @mde (released as of version 2.0.1)
- gitignore `node_modules` (local development)
- Ensure `tmp` directory is removed after tests run
- Hook jake's test task into `npm test` command

**Note**: a [pull request](https://github.com/mde/filelist/pull/4) is currently open that addresses some of the same issues. If that one is merged, I'm happy to update this one based on those changes.

Suggesting a release of this npm package if this pull is merged. Thanks!