### PR TITLE
Fix glob patterns (* and **) on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,6 +198,7 @@ globSync = function (pat, opts) {
 
   if (files) {
     pat = path.normalize(pat);
+    pat = pat.replace(/\\/g, '/')
     matches = minimatch.match(files, pat, opts || {});
   }
   return matches || [];

--- a/jakefile.js
+++ b/jakefile.js
@@ -1,5 +1,5 @@
 testTask('FileList', function () {
-  this.testFiles.include('test/*.js');
+  this.testFiles.include('test/filelist.js');
 });
 
 publishTask('FileList', function () {


### PR DESCRIPTION
Fixes #15 

Also enables the tests on Windows, by bypassing this bug. That fix should probably stay in here, since Jake depends on this module, so the behavior of `this.testFiles.include` won't include our fix until this PR is first merged into filelist, then jake is updated.